### PR TITLE
feat: graphql api

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,6 +22,8 @@ dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
     implementation("ru.tinkoff.invest:openapi-java-sdk-java8:0.5.2")
     implementation("com.squareup.okhttp3:okhttp:4.10.0")
+    implementation("com.graphql-java:graphql-java:20.0")
+    implementation ("org.springframework.boot:spring-boot-starter-graphql")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
 }
 

--- a/src/main/kotlin/com/alexeyodinochenko/tinkoffservice/controller/StockControllerGraphQL.kt
+++ b/src/main/kotlin/com/alexeyodinochenko/tinkoffservice/controller/StockControllerGraphQL.kt
@@ -7,9 +7,9 @@ import com.alexeyodinochenko.tinkoffservice.model.Stock
 import com.alexeyodinochenko.tinkoffservice.service.`interface`.StockService
 import org.springframework.graphql.data.method.annotation.Argument
 import org.springframework.graphql.data.method.annotation.QueryMapping
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.stereotype.Controller
 
-@RestController
+@Controller
 class StockControllerGraphQL(
     private val stockService: StockService
 ) {

--- a/src/main/kotlin/com/alexeyodinochenko/tinkoffservice/controller/StockControllerGraphQL.kt
+++ b/src/main/kotlin/com/alexeyodinochenko/tinkoffservice/controller/StockControllerGraphQL.kt
@@ -1,0 +1,30 @@
+package com.alexeyodinochenko.tinkoffservice.controller
+
+import com.alexeyodinochenko.tinkoffservice.dto.FigiesDto
+import com.alexeyodinochenko.tinkoffservice.dto.StockPriceDto
+import com.alexeyodinochenko.tinkoffservice.dto.TickersDto
+import com.alexeyodinochenko.tinkoffservice.model.Stock
+import com.alexeyodinochenko.tinkoffservice.service.`interface`.StockService
+import org.springframework.graphql.data.method.annotation.Argument
+import org.springframework.graphql.data.method.annotation.QueryMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class StockControllerGraphQL(
+    private val stockService: StockService
+) {
+    @QueryMapping
+    fun getStockByTicker(@Argument ticker: String): Stock {
+        return stockService.getStockByTicker(ticker)
+    }
+
+    @QueryMapping
+    fun getStocksByTickers(@Argument tickers: List<String>): List<Stock> {
+        return stockService.getStocksByTickers(TickersDto(tickers)).stocks
+    }
+
+    @QueryMapping
+    fun getPrices(@Argument figies: List<String>): List<StockPriceDto> {
+        return stockService.getStocksPrices(FigiesDto(figies)).prices
+    }
+}

--- a/src/main/kotlin/com/alexeyodinochenko/tinkoffservice/controller/StockControllerREST.kt
+++ b/src/main/kotlin/com/alexeyodinochenko/tinkoffservice/controller/StockControllerREST.kt
@@ -13,11 +13,11 @@ import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
-class StockController(
+class StockControllerREST(
     private val stockService: StockService
 ) {
     @GetMapping("/stocks/{ticker}")
-    fun getStock(@PathVariable ticker: String): Stock {
+    fun getStockByTicker(@PathVariable ticker: String): Stock {
         return stockService.getStockByTicker(ticker)
     }
 

--- a/src/main/kotlin/com/alexeyodinochenko/tinkoffservice/service/interface/StockService.kt
+++ b/src/main/kotlin/com/alexeyodinochenko/tinkoffservice/service/interface/StockService.kt
@@ -1,7 +1,6 @@
 package com.alexeyodinochenko.tinkoffservice.service.`interface`
 
 import com.alexeyodinochenko.tinkoffservice.dto.FigiesDto
-import com.alexeyodinochenko.tinkoffservice.dto.StockPriceDto
 import com.alexeyodinochenko.tinkoffservice.dto.StocksDto
 import com.alexeyodinochenko.tinkoffservice.dto.StocksPricesDto
 import com.alexeyodinochenko.tinkoffservice.dto.TickersDto

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,0 +1,4 @@
+server.port=8080
+api.isSandboxModeEnabled=true
+spring.graphql.graphiql.enabled=true
+spring.graphql.graphiql.path=/graphiql

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,5 +1,0 @@
-server:
-  port: 8004
-
-api:
-  isSandboxModeEnabled: true

--- a/src/main/resources/graphql/schema.graphqls
+++ b/src/main/resources/graphql/schema.graphqls
@@ -1,0 +1,35 @@
+type Query {
+    getStockByTicker(ticker: String): Stock
+    getStocksByTickers(tickers: [String]): [Stock]
+    getPrices(figies: [String]): [StockPriceDto]
+}
+
+type StocksDto {
+    tickers: [Stock]
+}
+
+type StockPriceDto {
+    figi: String,
+    price: String
+}
+
+type Stock {
+    ticker: String,
+    figi: String,
+    name: String,
+    type: String,
+    currency: Currency,
+    source: String
+}
+
+enum Currency {
+    RUB
+    USD
+    EUR
+    GBP
+    HKD
+    CHF
+    JPY
+    CNY
+    TRY
+}


### PR DESCRIPTION
Реализовал GraphQL Api путем добавления схемы, где описал главный тип Quary через который и отправляем запросы и остальные типы для нормальной работы запросов. Протестировал с помощью нативного интерфейса GraphQL, который вызывается по эндпоинту localhost:8080/graphql, так же протестировал через Altair. Прикрепляю готовые запросы для тестов

```
query {
  getStocksByTickers(tickers: ["SBER", "YNDX"]) {
    ticker,
    figi,
    name,
    type,
    currency,
    source
  }
}
query {
  getStockByTicker(ticker: "SBER") {
    ticker,
    figi,
    name,
    type,
    currency,
    source
  }
}
query {
  getPrices(figies: ["BBG004730N88", "BBG006L8G4H1"]) {
    figi
    price
  }
}
```